### PR TITLE
return detailed error msgs, rename vars

### DIFF
--- a/R/get_location.R
+++ b/R/get_location.R
@@ -8,45 +8,69 @@
 #' ## get type 2  locations reported by ADFG
 #' adfg2<-get_locaton(token="your-api-key", reporting_agency="ADFG", location_type=2)
 
-get_location<-function(token=NA, ...) {
 
-  start_time<-Sys.time()
-  url<-"https://phish.rmis.org/location"
-  # function to determine the number of pages needed
-  get_totalCount<-function(token, ...) {
-    url<-"https://phish.rmis.org/location"
-    query<-list(...=...)
-    httr::content(
-      httr::GET(url, query=query, httr::add_headers(xapikey=token)) %>%
-        httr::stop_for_status())$totalCount
+get_location <- function(token=NA, ...) {
+  start_time <- Sys.time()
+  url <- "https://phish.rmis.org/location"
+  
+  get_totalCount <- function(token, ...) {
+    url <- "https://phish.rmis.org/location"
+    query <- list(... = ...)
+    response <- GET(url, query = query, add_headers(xapikey = token))
+
+    # Check if the response has an error
+    if (http_error(response)) {
+      # Extract and parse content from the response
+      content <- content(response, "text", encoding = "UTF-8")
+      error_info <- fromJSON(content)
+      # Extract only the main error message
+      main_error_message <- error_info$message
+      # Suppress fxn info printing when stop
+      stop(main_error_message, call. = FALSE)
+    } else {
+      # Extract totalCount if no error
+      return(content(response)$totalCount)
+    }
   }
-
+  
+  
   #function to pull by page 1000 records at time
-  get_by_page <- function(token=NA, page=1, ...) {
-    url<-"https://phish.rmis.org/location"
-    query<-list(page=page,
-                perpage=1000,
-                ...=...)
-    jsonlite::fromJSON(httr::content(
-      httr::GET(url, query=query, httr::add_headers(xapikey=token)) %>%
-        httr::stop_for_status(), type= "text"))$records %>%
-      dplyr::bind_rows()
+  get_by_page <- function(token = NA, page = 1, ...) {
+    url <- "https://phish.rmis.org/location"
+    query <- list(page = page, perpage = 1000, ... = ...)
+    response <- GET(url, query = query, add_headers(xapikey = token))
+
+    # Check if the response has an error
+    if (http_error(response)) {
+      # Extract and parse content from the response
+      content <- content(response, "text", encoding = "UTF-8")
+      error_info <- fromJSON(content)
+      
+      # Extract only the main error message
+      main_error_message <- error_info$message
+      # Suppress fxn info printing when stop
+      stop(main_error_message, call. = FALSE)
+    } else {
+      # Process the successful response
+      fromJSON(content(response, type = "text"))$records %>%
+        bind_rows()
+    }
   }
 
   # determine record count and number of pages needed
-  tc<-suppressMessages(get_totalCount(token=token, ...))
-
-  npage<-ceiling(tc/1000)
+  totalcount <- suppressMessages(get_totalCount(token = token, ...))
+  
+  numberpages <- ceiling(totalcount / 1000)
 
   # write message for the potentially slow function
-  message(paste0("Downloading ", tc, " records"))
+  message(paste0("Downloading ", totalcount, " records"))
 
   # apply the api pull function across the number of pages
-  data<-suppressMessages(lapply(1:npage, FUN=function(x) {get_by_page(token=token,
+  data <- suppressMessages(lapply(1:numberpages, FUN=function(x) {get_by_page(token=token,
                                                                             page=x,
                                                                             ...)})%>%dplyr::bind_rows())
   # time
-  end_time<-Sys.time()
+  end_time <- Sys.time()
   message(paste("Time Elapsed:", round(end_time - start_time, 2),
                 units(end_time - start_time)))
 


### PR DESCRIPTION
-Updated get_location() nested functions to return the message part of error messages since the RMIS API errors returned detailed information explaining errors in many conditions which can be helpful to the end user.

-Renamed several variables (like tc -> totalcount) to improve code's initial readability and use as a teaching resource. 