### PR TITLE
Enhance/zero record count handling, option to return total count only

### DIFF
--- a/R/get_catchsample.R
+++ b/R/get_catchsample.R
@@ -58,6 +58,11 @@ get_catchsample<-function(token=NA, ...) {
   # determine record count and number of pages needed
   totalcount <- suppressMessages(get_totalCount(token = token, ...))
 
+  if (totalcount == 0) {
+    message("No records found.")
+    return(data.frame()) # Returning an empty data frame if no records are found
+  }
+
   numberpages <- ceiling(totalcount / 1000)
 
   # write message for the potentially slow function

--- a/R/get_catchsample.R
+++ b/R/get_catchsample.R
@@ -9,7 +9,7 @@
 #' ## get chinook catch samples for 1990 reported by ADFG of species 1
 #' adfg1990<-get_catchsample(token="your-api-key", reporting_agency="ADFG", catch_year=1990, species = 1)
 
-get_catchsample<-function(token=NA, ...) {
+get_catchsample<-function(token=NA, only_count = FALSE, ...) {
   start_time <- Sys.time()
   url <- "https://phish.rmis.org/catchsample"
 
@@ -61,6 +61,11 @@ get_catchsample<-function(token=NA, ...) {
   if (totalcount == 0) {
     message("No records found.")
     return(data.frame()) # Returning an empty data frame if no records are found
+  }
+
+  if (only_count) {
+    # If only the count is requested, return here
+    return(totalcount)
   }
 
   numberpages <- ceiling(totalcount / 1000)

--- a/R/get_location.R
+++ b/R/get_location.R
@@ -58,6 +58,11 @@ get_location <- function(token=NA, ...) {
   # determine record count and number of pages needed
   totalcount <- suppressMessages(get_totalCount(token = token, ...))
 
+  if (totalcount == 0) {
+    message("No records found.")
+    return(data.frame()) # Returning an empty data frame if no records are found
+  }
+
   numberpages <- ceiling(totalcount / 1000)
 
   # write message for the potentially slow function

--- a/R/get_location.R
+++ b/R/get_location.R
@@ -9,7 +9,7 @@
 #' adfg2<-get_locaton(token="your-api-key", reporting_agency="ADFG", location_type=2)
 
 
-get_location <- function(token=NA, ...) {
+get_location <- function(token=NA, only_count = FALSE, ...) {
   start_time <- Sys.time()
   url <- "https://phish.rmis.org/location"
 
@@ -61,6 +61,11 @@ get_location <- function(token=NA, ...) {
   if (totalcount == 0) {
     message("No records found.")
     return(data.frame()) # Returning an empty data frame if no records are found
+  }
+
+  if (only_count) {
+    # If only the count is requested, return here
+    return(totalcount)
   }
 
   numberpages <- ceiling(totalcount / 1000)

--- a/R/get_recovery.R
+++ b/R/get_recovery.R
@@ -11,7 +11,7 @@
 #' ## get chinook recovery for 1990 reported by ADFG of species 1
 #' adfg1990<-get_recovery(token="your-api-key", reporting_agency="ADFG", run_year=1990, species = 1)
 
-get_recovery<-function(token=NA, ...) {
+get_recovery<-function(token=NA, only_count = FALSE, ...) {
 
   start_time<-Sys.time()
   url<-"https://phish.rmis.org/recovery"
@@ -64,6 +64,11 @@ get_recovery<-function(token=NA, ...) {
   if (totalcount == 0) {
     message("No records found.")
     return(data.frame()) # Returning an empty data frame if no records are found
+  }
+
+  if (only_count) {
+    # If only the count is requested, return here
+    return(totalcount)
   }
 
   numberpages<-ceiling(totalcount/1000)

--- a/R/get_recovery.R
+++ b/R/get_recovery.R
@@ -61,6 +61,11 @@ get_recovery<-function(token=NA, ...) {
   # determine record count and number of pages needed
   totalcount<-suppressMessages(get_totalCount(token=token, ...))
 
+  if (totalcount == 0) {
+    message("No records found.")
+    return(data.frame()) # Returning an empty data frame if no records are found
+  }
+
   numberpages<-ceiling(totalcount/1000)
 
   if(totalcount>500000) {

--- a/R/get_release.R
+++ b/R/get_release.R
@@ -8,7 +8,7 @@
 #' ## get chinook releases for 1990 reported by ADFG
 #' adfg1990<-get_release(token="your-api-key", reporting_agency="ADFG", brood_year=1990)
 
-get_release<-function(token=NA, ...) {
+get_release<-function(token=NA, only_count = FALSE, ...) {
   start_time <- Sys.time()
   url <- "https://phish.rmis.org/release"
 
@@ -60,6 +60,11 @@ get_release<-function(token=NA, ...) {
   if (totalcount == 0) {
     message("No records found.")
     return(data.frame()) # Returning an empty data frame if no records are found
+  }
+
+  if (only_count) {
+    # If only the count is requested, return here
+    return(totalcount)
   }
 
   numberpages <- ceiling(totalcount / 1000)

--- a/R/get_release.R
+++ b/R/get_release.R
@@ -57,6 +57,11 @@ get_release<-function(token=NA, ...) {
   # determine record count and number of pages needed
   totalcount <- suppressMessages(get_totalCount(token = token, ...))
 
+  if (totalcount == 0) {
+    message("No records found.")
+    return(data.frame()) # Returning an empty data frame if no records are found
+  }
+
   numberpages <- ceiling(totalcount / 1000)
 
   # write message for the potentially slow function


### PR DESCRIPTION
This enhances handling the situation where total count is zero and immediately returns a message instead. Also added new input parameter for all functions called only_count to allow for just returning the count and not following with the data. Helpful during debugging clients. 